### PR TITLE
Prevent references from being split across two pages

### DIFF
--- a/Journal/isuthesistagged.cls
+++ b/Journal/isuthesistagged.cls
@@ -681,8 +681,10 @@
 \let\@afterindentfalse\@afterindenttrue
 \@afterindenttrue
 %%%%
+%% Prevent orphan and widow lines
 \usepackage[all]{nowidow}
-%
+%% Prevent references from being split across two pages
+\AtBeginEnvironment{thebibliography}{\interlinepenalty=10000}
 
 %%%%%%%%%%%%%%%%%%2025 fixes and new packages
 \newcommand{\frontmattersetup}{

--- a/Traditional/isuthesistagged.cls
+++ b/Traditional/isuthesistagged.cls
@@ -681,8 +681,10 @@
 \let\@afterindentfalse\@afterindenttrue
 \@afterindenttrue
 %%%%
+%% Prevent orphan and widow lines
 \usepackage[all]{nowidow}
-%
+%% Prevent references from being split across two pages
+\AtBeginEnvironment{thebibliography}{\interlinepenalty=10000}
 
 %%%%%%%%%%%%%%%%%%2025 fixes and new packages
 \newcommand{\frontmattersetup}{


### PR DESCRIPTION
Technically no longer a rejectable requirement since December 2024, but is now designated as a recommendation.